### PR TITLE
Commit Next.js auto-generated agent guidance files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Commits `AGENTS.md` and `CLAUDE.md`, which Next.js 16.3+'s `next dev` auto-generates on every local run to warn AI coding assistants that their training data may predate this version's API/convention changes
- The file's own note explains it'll keep reappearing as an uncommitted diff on every `next dev` run unless committed, so this just stops that recurring noise
- No functional/app code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)